### PR TITLE
Simplify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cd firetail-appsync-lambda/logs-hander
 Before building the source into a binary, set `GOARCH` to `amd64` and `GOOS` to `linux` to ensure the binary will be compatible with the [Lambda Go runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html):
 
 ```bash
-GOARCH=amd64 GOOS=linux
+export GOARCH=amd64 GOOS=linux
 ```
 
 Next, build the binary and output it into a `bin` directory at the root of the repository. `-ldflags="-s -w"` can be used to marginally reduce the size of the binary:

--- a/README.md
+++ b/README.md
@@ -72,34 +72,15 @@ Create an account at [Firetail.App](https://firetail.app/), then:
 
 ### Building The Firetail AppSync Lambda
 
-The Firetail AppSync Lambda is written in Go, and can be built using the standard `go build` command. First, clone the repository and change directory into `logs-handler`, where the Lambda's source is located:
-
-```bash
-git clone git@github.com:FireTail-io/firetail-appsync-lambda.git
-cd firetail-appsync-lambda/logs-hander
-```
-
-Before building the source into a binary, set `GOARCH` to `amd64` and `GOOS` to `linux` to ensure the binary will be compatible with the [Lambda Go runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html):
-
-```bash
-export GOARCH=amd64 GOOS=linux
-```
-
-Next, build the binary and output it into a `bin` directory at the root of the repository. `-ldflags="-s -w"` can be used to marginally reduce the size of the binary:
-
-```bash
-go build -ldflags="-s -w" -o ../bin/logs-handler
-```
-
-The [serverless.yml](./serverless.yml) provided in the root of this repository can be used to deploy this binary to Lambda, and expects the binary to be found in a `bin` directory at the root of the repository, hence `-o ../bin/logs-handler`.
-
-The process of building the Firetail AppSync Lambda binary can alternatively be performed using [the Makefile at the root of this repository](./Makefile), using the `build` target:
+The process of building the Firetail AppSync Lambda binary can be performed using [the Makefile at the root of this repository](./Makefile), using the `build` target:
 
 ```bash
 git clone git@github.com:FireTail-io/firetail-appsync-lambda.git
 cd firetail-appsync-lambda
 make build
 ```
+
+A more in-depth explanation of how to build the Firetail AppSync Lambda from source can be found in [docs/build-from-src.md](./docs/build-from-src.md).
 
 
 

--- a/docs/build-from-src.md
+++ b/docs/build-from-src.md
@@ -1,0 +1,22 @@
+## Building The Firetail AppSync Lambda From Source
+
+The Firetail AppSync Lambda is written in Go, and can be built using the standard `go build` command. First, clone the repository and change directory into `logs-handler`, where the Lambda's source is located:
+
+```bash
+git clone git@github.com:FireTail-io/firetail-appsync-lambda.git
+cd firetail-appsync-lambda/logs-hander
+```
+
+Before building the source into a binary, set `GOARCH` to `amd64` and `GOOS` to `linux` to ensure the binary will be compatible with the [Lambda Go runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html):
+
+```bash
+export GOARCH=amd64 GOOS=linux
+```
+
+Next, build the binary and output it into a `bin` directory at the root of the repository. `-ldflags="-s -w"` can be used to marginally reduce the size of the binary:
+
+```bash
+go build -ldflags="-s -w" -o ../bin/logs-handler
+```
+
+The [serverless.yml](./serverless.yml) provided in the root of this repository can be used to deploy this binary to Lambda, and expects the binary to be found in a `bin` directory at the root of the repository, hence `-o ../bin/logs-handler`.


### PR DESCRIPTION
- Moves the docs for building without makefile into docs subdir as it caused confusion
- Adds export prefix to env vars in docs